### PR TITLE
refactor: 사과 조합 찾기 알고리즘 변경

### DIFF
--- a/Apple_Game/Assets/AppleGame/1.Scripts/GameManager.cs
+++ b/Apple_Game/Assets/AppleGame/1.Scripts/GameManager.cs
@@ -5,55 +5,67 @@ using TMPro;
 using DG.Tweening;
 using System.Collections;
 using System.Linq;
+using System;
 
 public class GameManager : MonoBehaviour
 {
+
+    #region Variables
+
     [Header("--------------[ Game Control ]")]
-    private int score = 0;                          // 현재 게임 점수
-    private int highScore = 0;                      // 최고 점수
-    private int appleScore = 10;                    // 기본 사과 점수
-    private int destroyedApples = 0;                // 터뜨린 사과 개수
-    [HideInInspector] public bool isGameOver;       // 게임 종료 상태 여부
-    [HideInInspector] public bool isCountingDown;   // 카운트다운 진행 중 여부
-    private int remainingResets = 2;                // 남은 숫자 재설정 횟수
+    private int score = 0;                              // 현재 게임 점수
+    private int highScore = 0;                          // 최고 점수
+    private int appleScore = 10;                        // 기본 사과 점수
+    private int destroyedApples = 0;                    // 터뜨린 사과 개수
+    [HideInInspector] public bool isGameOver;           // 게임 종료 상태 여부
+    [HideInInspector] public bool isCountingDown;       // 카운트다운 진행 중 여부
+    private int remainingResets = 2;                    // 남은 숫자 재설정 횟수
 
     [Header("--------------[ Game Setting ]")]
-    public GameObject applePrefab;                  // 사과 Prefab
-    public Transform appleGroup;                    // 오브젝트 풀링을 설정할 사과 부모 오브젝트
-    private List<Apple> applePool;                  // 사과 오브젝트 풀
-    private const int POOL_SIZE = 120;              // 오브젝트 풀 Size
-    private const int TARGET_COUNT = 3;             // 보너스 점수를 위한 사과 객체 카운트
+    [SerializeField] private GameObject applePrefab;    // 사과 프리펩
+    [SerializeField] private Transform appleGroup;      // 오브젝트 풀링을 설정할 사과 부모 오브젝트
+    private List<Apple> applePool;                      // 사과 오브젝트 풀 List
+    private const int POOL_SIZE = 120;                  // 오브젝트 풀 최대 크기
+    private const int GRID_WIDTH = 15;                  // 게임 그리드 가로 사이즈
+    private const int GRID_HEIGHT = 8;                  // 게임 그리드 세로 사이즈
+    private const int TARGET_COUNT = 3;                 // 보너스 점수를 위한 최소 사과 개수
 
-    [HideInInspector] public GameObject[] appleObjects;             // 활성화된 사과 배열
-    [HideInInspector] public List<GameObject> selectedApples;       // 현재 선택된 사과들
-    [HideInInspector] public List<GameObject> lastSelectedApples;   // 이전에 선택된 사과들
+    [HideInInspector] public GameObject[] appleObjects;                     // 활성화된 사과 오브젝트 배열
+    [HideInInspector] public List<GameObject> selectedApples;               // 현재 선택된 사과 오브젝트 List
+    [HideInInspector] public List<GameObject> lastSelectedApples;           // 이전에 선택된 사과 오브젝트 List
 
-    [Header("--------------[ UI ]")]
-    public TextMeshProUGUI scoreText;               // ScoreGroup의 Score Text
-    public TextMeshProUGUI endScoreText;            // EndGroup의 End ScoreText
-    public GameObject endGroup;                     // Canvas의 EndGroup
-    public RectTransform appleImageRect;            // EndGroup의 Apple Image의 좌표
-    public TextMeshProUGUI timeText;                // 남은 시간을 표시할 Text
-    public TextMeshProUGUI destroyedAppleCountText; // 터뜨린 사과의 개수 Text
+    private HashSet<string> positionCombinations = new HashSet<string>();   // 유효한 사과 조합의 위치 정보를 저장하는 HashSet
+    private List<Vector2Int> tempPositions = new List<Vector2Int>(50);      // 조합 계산 시 임시로 사용하는 위치 List
+    private List<int> tempNumbers = new List<int>(50);                      // 조합 계산 시 임시로 사용하는 숫자 List
 
-    public GameObject setNumberPanel;               // Canvas의 SetNumberPanel
-    public TextMeshProUGUI countDownText;           // SetNumberPanel의 카운트다운 Text
-    private int countDown = 3;                      // 카운트다운
+    [Header("--------------[ UI References ]")]
+    [SerializeField] private TextMeshProUGUI scoreText;                     // 현재 점수를 표시하는 Text (ScoreGroup의 Score Text)
+    [SerializeField] private TextMeshProUGUI endScoreText;                  // 게임 종료 시 점수를 표시하는 Text (EndGroup의 End ScoreText)
+    [SerializeField] private GameObject endGroup;                           // 게임 종료 UI 그룹 (Canvas의 EndGroup)
+    [SerializeField] private RectTransform appleImageRect;                  // 게임 종료 시 떨어지는 사과 이미지의 RectTransform (EndGroup의 Apple Image의 좌표)
+    [SerializeField] private TextMeshProUGUI timeText;                      // 남은 게임 시간을 표시하는 Text
+    [SerializeField] private TextMeshProUGUI destroyedAppleCountText;       // 터뜨린 사과 개수를 표시하는 Text
+
+    [SerializeField] private GameObject setNumberPanel;                     // 숫자 재설정 시 표시되는 패널 (Canvas의 SetNumberPanel)
+    [SerializeField] private TextMeshProUGUI countDownText;                 // 숫자 재설정 카운트다운 Text
+    private int countDown = 3;                                              // 숫자 재설정 카운트다운 초기값
 
     [Header("--------------[ Gaugebar ]")]
-    public Slider timeSlider;                       // UI에 표시할 게이지바
-    private const float TIME_LIMIT = 60f;           // 기본 시간 제한(초)
-    private float currentTime;                      // 현재 시간
+    [SerializeField] private Slider timeSlider;         // 남은 시간을 표시하는 게이지바
+    private const float TIME_LIMIT = 60f;               // 게임 제한 시간(초)
+    private float currentTime;                          // 현재 남은 시간
 
     [Header("--------------[ Effects ]")]
-    public GameObject effectPrefab;                 // 이펙트 프리팹
+    [SerializeField] private GameObject effectPrefab;   // 사과 매칭 시 생성되는 이펙트 프리팹
 
     [Header("--------------[ ETC ]")]
-    public DragManager dragManager;                 // DragManager 참조
-    private Camera mainCamera;                      // mainCamera 참조
-    private readonly WaitForSeconds effectDestroyDelay = new WaitForSeconds(1f);
+    [SerializeField] private DragManager dragManager;   // DragManager 참조
+    private Camera mainCamera;                          // mainCamera 참조
 
-    // =======================================================================================================
+    #endregion
+
+
+    #region Unity Methods
 
     private void Awake()
     {
@@ -83,9 +95,12 @@ public class GameManager : MonoBehaviour
         }
     }
 
-    // =======================================================================================================
+    #endregion
 
-    // 초기화
+
+    #region Initialize
+
+    // 게임 초기 설정 함수
     private void InitializeGame()
     {
         mainCamera = Camera.main;
@@ -118,6 +133,11 @@ public class GameManager : MonoBehaviour
         currentTime = TIME_LIMIT;
         UpdateTimeUI();
     }
+
+    #endregion
+
+
+    #region Apple Selection & Matching
 
     // 새로운 사과 오브젝트 생성 함수
     public void MakeApple()
@@ -163,7 +183,6 @@ public class GameManager : MonoBehaviour
         }
         else
         {
-            // 선택 초기화
             ClearSelectedApples();
         }
     }
@@ -173,18 +192,24 @@ public class GameManager : MonoBehaviour
     {
         // 사과들을 드롭
         int count = matchedApples.Count;
+        Apple[] appleComponents = new Apple[count];
+
         for (int i = 0; i < count; i++)
         {
-            if (matchedApples[i].TryGetComponent<Apple>(out Apple appleComponent))
-            {
-                appleComponent.DropApple();
-            }
+            appleComponents[i] = matchedApples[i].GetComponent<Apple>();
+            appleComponents[i].DropApple();
         }
 
         // 드롭 애니메이션이 완료될 때까지 대기 (2초)
         yield return new WaitForSeconds(2f);
 
-        // 드래그 중일 때의 처리 (예외 처리)
+        // 게임 종료 확인
+        if (isGameOver)
+        {
+            yield break;
+        }
+
+        // 드래그 중일 때의 처리
         if (dragManager.isDrag)
         {
             // 현재 드래그 중인 사과들의 정보를 임시 저장
@@ -199,34 +224,30 @@ public class GameManager : MonoBehaviour
                 int sum = 0;
                 for (int i = 0; i < tempSelectedApples.Count; i++)
                 {
-                    if (tempSelectedApples[i].TryGetComponent<Apple>(out Apple appleComponent))
-                    {
-                        sum += appleComponent.appleNum;
-                    }
+                    sum += tempSelectedApples[i].GetComponent<Apple>().appleNum;
                 }
 
                 // 합이 10이면 현재 코루틴 종료 (새로운 매치가 발생할 것이므로)
                 if (sum == 10)
                 {
+                    // 새로운 매치가 발생했더라도 현재 상태의 조합 개수는 계산
+                    CalculatePossibleCombinations();
                     yield break;
                 }
             }
         }
 
-        // 해당 드롭 애니메이션 제외 다른 모든 드롭 애니메이션이 완료되었는지 확인 (예외 처리)
-        for (int i = 0; i < applePool.Count; i++)
+        // 드롭 중인 사과 확인
+        bool isAnyDropping = applePool.Any(apple => apple.isDropping);
+        if (isAnyDropping)
         {
-            if (applePool[i].isDropping)
-            {
-                yield break;
-            }
+            CalculatePossibleCombinations();
+            yield break;
         }
 
-        // 게임 종료 확인 (예외 처리)
-        if (isGameOver) yield break;
-
         // 가능한 조합 계산
-        if (CalculatePossibleCombinations() <= 5 && !setNumberPanel.activeSelf && remainingResets > 0)
+        int possibleCombinations = CalculatePossibleCombinations();
+        if (possibleCombinations <= 3 && !setNumberPanel.activeSelf && remainingResets > 0)
         {
             remainingResets--;
             StartCoroutine(StartCountdownAndRandomize());
@@ -253,11 +274,11 @@ public class GameManager : MonoBehaviour
     // 생성된 이펙트를 일정 시간 후 제거하는 코루틴
     private IEnumerator DestroyEffectAfterDelay(GameObject effect)
     {
-        yield return effectDestroyDelay;
+        yield return new WaitForSeconds(1f);
         Destroy(effect);
     }
 
-    // 선택된 사과들 초기화
+    // 선택된 사과들 초기화 함수
     public void ClearSelectedApples()
     {
         int count = selectedApples.Count;
@@ -301,7 +322,10 @@ public class GameManager : MonoBehaviour
         }
     }
 
-    // =======================================================================================================
+    #endregion
+
+
+    #region Score & UI
 
     // 점수 추가 함수
     private void AddScore()
@@ -387,90 +411,93 @@ public class GameManager : MonoBehaviour
         appleImageRect.DOMoveY(targetY, 1f).SetEase(Ease.OutBounce);
     }
 
-    // =======================================================================================================
+    #endregion
 
-    // 가능한 합 10 조합 계산
+
+    #region Apple Combination Calculation
+
+    // 사과 조합 가능 수 계산 (중복 제외)
     private int CalculatePossibleCombinations()
     {
-        const int GRID_WIDTH = 15;
-        const int GRID_HEIGHT = 8;
-
-        // 2차원 배열로 사과 그리드 생성
-        int[,] appleGrid = new int[GRID_HEIGHT, GRID_WIDTH];
-
-        // 그리드에 사과 숫자 채우기
-        for (int i = 0; i < POOL_SIZE; i++)
-        {
-            if (appleObjects[i].TryGetComponent<Apple>(out Apple appleComponent))
-            {
-                int row = i / GRID_WIDTH;
-                int col = i % GRID_WIDTH;
-                appleGrid[row, col] = appleComponent.appleNum;
-            }
-        }
-
-        int possibleCombinations = 0;
+        positionCombinations.Clear();
 
         // 모든 가능한 직사각형 영역 검사
         for (int startRow = 0; startRow < GRID_HEIGHT; startRow++)
         {
             for (int startCol = 0; startCol < GRID_WIDTH; startCol++)
             {
-                // 직사각형의 높이와 너비를 변경하며 검사 (최대 4x4 크기까지)
-                for (int height = 1; height <= Mathf.Min(4, GRID_HEIGHT - startRow); height++)
+                // 시작 위치의 사과가 유효하지 않으면 스킵
+                Apple startApple = appleObjects[startRow * GRID_WIDTH + startCol].GetComponent<Apple>();
+                if (startApple == null || startApple.appleNum <= 0)
                 {
-                    for (int width = 1; width <= Mathf.Min(4, GRID_WIDTH - startCol); width++)
+                    continue;
+                }
+
+                // 가능한 모든 직사각형 크기에 대해 조합 가능 수 계산
+                for (int height = 1; height <= Math.Min(GRID_HEIGHT, GRID_HEIGHT - startRow); height++)
+                {
+                    for (int width = 1; width <= Math.Min(GRID_WIDTH, GRID_WIDTH - startCol); width++)
                     {
-                        int sum = 0;
-                        int validNumbers = 0;
-                        List<Vector2Int> positions = new List<Vector2Int>();
-                        List<int> numbers = new List<int>();
-
-                        // 현재 직사각형 영역 내의 숫자들 확인
-                        for (int r = startRow; r < startRow + height; r++)
-                        {
-                            for (int c = startCol; c < startCol + width; c++)
-                            {
-                                if (appleGrid[r, c] > 0)
-                                {
-                                    sum += appleGrid[r, c];
-                                    validNumbers++;
-                                    positions.Add(new Vector2Int(r, c));
-                                    numbers.Add(appleGrid[r, c]);
-                                }
-                            }
-                        }
-
-                        // 합이 10이고 2개 이상의 숫자가 사용된 경우
-                        if (sum == 10 && validNumbers >= 2)
-                        {
-                            possibleCombinations++;
-                            string positionStr = string.Join(", ", positions.Select(p => $"({p.x},{p.y})"));
-                            string numberStr = string.Join(" + ", numbers);
-                            //Debug.Log($"조합 {possibleCombinations}: {numberStr} = 10 at positions {positionStr}");
-                        }
+                        CheckRectangleArea(startRow, startCol, height, width, GRID_WIDTH);
                     }
                 }
             }
         }
 
-        //Debug.Log($"조합 가능 개수 : {possibleCombinations}");
-        return possibleCombinations;
+        int count = positionCombinations.Count;
+        //Debug.Log($"조합 가능 개수: {count}");
+        return count;
     }
 
-    // 사과 숫자 랜덤 변경
+    // 주어진 크기에 맞게 조합 가능 수 계산 함수
+    private void CheckRectangleArea(int startRow, int startCol, int height, int width, int gridWidth)
+    {
+        tempPositions.Clear();
+        tempNumbers.Clear();
+        int sum = 0;
+        bool hasValidApples = false;
+
+        // 직사각형 영역 내의 모든 사과 수집
+        for (int r = startRow; r < startRow + height; r++)
+        {
+            for (int c = startCol; c < startCol + width; c++)
+            {
+                Apple apple = appleObjects[r * gridWidth + c].GetComponent<Apple>();
+                if (apple != null && apple.appleNum > 0)
+                {
+                    tempPositions.Add(new Vector2Int(r, c));
+                    tempNumbers.Add(apple.appleNum);
+                    sum += apple.appleNum;
+                    hasValidApples = true;
+                }
+            }
+        }
+
+        // 유효한 사과가 2개 이상이고 합이 10인 경우만 처리
+        if (hasValidApples && tempNumbers.Count >= 2 && sum == 10)
+        {
+            // 위치들을 정렬하여 일관된 키 생성
+            tempPositions.Sort((a, b) => (a.x * gridWidth + a.y).CompareTo(b.x * gridWidth + b.y));
+
+            // 중복 체크
+            string positionKey = string.Join("|", tempPositions.Select(p => $"{p.x},{p.y}"));
+            if (!positionCombinations.Contains(positionKey))
+            {
+                positionCombinations.Add(positionKey);
+            }
+        }
+    }
+
+    // 사과 숫자 랜덤 변경 함수
     private void RandomizeAppleNumbers()
     {
-        int count = appleObjects.Length;
-        for (int i = 0; i < count; i++)
+        Apple[] appleComponents = new Apple[appleObjects.Length];
+        for (int i = 0; i < appleObjects.Length; i++)
         {
-            if (appleObjects[i].TryGetComponent<Apple>(out Apple appleComponent))
+            appleComponents[i] = appleObjects[i].GetComponent<Apple>();
+            if (appleComponents[i].appleNum > 0)
             {
-                // 아직 남아있는 사과에만 숫자 재설정
-                if (appleComponent.appleNum > 0)
-                {
-                    appleComponent.SetRandomNumber();
-                }
+                appleComponents[i].SetRandomNumber();
             }
         }
     }
@@ -505,8 +532,7 @@ public class GameManager : MonoBehaviour
         isCountingDown = false;
     }
 
-    // =======================================================================================================
-
+    #endregion
 
 
 }


### PR DESCRIPTION
1. 기존 사과 조합 찾기 알고리즘에서 변경
- 기존 : 4x4크기까지의 직사각형 영역 검사 / 중복도 같이 카운트 되었음
- 변경 : 모든 직사각형 영역 검사 / 중복 제거

- List 재사용으로 인한 가비지 컬렉션 부하 감소와 초기 용량 지정으로 동적 확장 최소화로 메모리 사용량을 감소
- HashSet 사용으로 종복 조합 체크 성능 향상 및 조기 종료 조건으로 불필요한 연산 감소
- 전체적인 성능 향샹, 코드 가독성 및 유지보수성 개선

2. 코드 리팩토링